### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ dependencies:
   - seaborn>=0.11.0
   - pip
   - pip:
-    - pyautogen>=0.2.0
+    - ag2>=0.2.0
     - yfinance>=0.1.70
 ```
 
@@ -175,7 +175,7 @@ else:
 ### AutoGen Issues
 - Ensure your OpenAI API key is valid and set correctly
 - Check if you have sufficient API credits
-- Try upgrading to the latest version of `pyautogen`
+- Try upgrading to the latest version of `ag2`
 
 ## Performance Metrics
 - **Total Return**: The final cumulative return of the strategy

--- a/environment.yaml
+++ b/environment.yaml
@@ -103,7 +103,7 @@ dependencies:
       - psutil==7.0.0
       - ptyprocess==0.7.0
       - pure-eval==0.2.3
-      - pyautogen==0.7.5
+      - ag2==0.7.5
       - pycparser==2.22
       - pydantic==2.10.6
       - pydantic-core==2.27.2

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "numpy>=1.20.0",
         "matplotlib>=3.5.0",
         "yfinance>=0.2.0",
-        "pyautogen>=0.7.0",
+        "ag2>=0.7.0",
         "streamlit>=1.22.0",
         "plotly>=5.13.0",
         "jupyter>=1.0.0",


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
